### PR TITLE
Update GitHub workflow to no longer use disabled "add-path" command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           yarn global:install
-          echo "::add-path::$(yarn global bin)"
+          echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: Generate the theme
         run: |
           figma2theme generate-json


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/